### PR TITLE
Tweak API to align with JS's (and doc).

### DIFF
--- a/demo/src/main/scala/react/table/demo/DemoMain.scala
+++ b/demo/src/main/scala/react/table/demo/DemoMain.scala
@@ -34,7 +34,21 @@ object DemoMain {
 
   val randomData = RandomData.randomPeople(1000)
 
-  val sortedTable = {
+  // TABLE 1
+  val SortedTableDef = TableMaker[Guitar].withSort
+  import SortedTableDef.syntax._
+
+  val SortedTable =
+    HTMLTableBuilder.buildComponent(
+      SortedTableDef,
+      tableClass = Css("guitars"),
+      headerCellFn = Some(HTMLTableBuilder.sortableHeaderCellFn()),
+      footer = <.tfoot(<.tr(<.th(^.colSpan := 6, s"Guitar Count: ${guitars.length}")))
+    )
+
+  import ColumnInterfaceBasedOnValue._
+
+  val sortedTableColumns = {
     val idRenderer = ScalaComponent
       .builder[Guitar]
       .render_P(props => <.span(s"g-${props.id}"))
@@ -43,104 +57,78 @@ object DemoMain {
       .toJsComponent
       .raw
 
-    val tableMaker = TableMaker[Guitar].withSort
-    import tableMaker.syntax._
-
-    val columns = tableMaker.columnArray(
-      tableMaker
-        .componentColumn("id", idRenderer)
+    List(
+      SortedTableDef
+        .Column("id", _.id)
+        .setCell(idRenderer)
         .setSortByFn[Int](_.id)
-        .setHeader("Id")
-        .setAccessorFn(_.id),
-      tableMaker.accessorColumn("make", _.make).setHeader("Make"),
-      tableMaker.accessorColumn("model", _.model).setHeader("Model"),
-      tableMaker.columnGroup(
-        "Details",
-        tableMaker.accessorColumn("year", _.details.year).setHeader("Year"),
-        tableMaker.accessorColumn("pickups", _.details.pickups).setHeader("Pickups"),
-        tableMaker.accessorColumn("color", _.details.color).setHeader("Color")
-      )
-    )
-
-    val state   = tableMaker.emptyState.setSortByVarargs(SortingRule("model"))
-    val options = tableMaker
-      .options(rowIdFn = _.id.toString, columns = columns)
-      .setInitialStateFull(state)
-
-    val guitarFooter = <.tfoot(<.tr(<.th(^.colSpan := 6, s"Guitar Count: ${guitars.length}")))
-
-    HTMLTableBuilder.buildComponent(
-      tableMaker,
-      options = options,
-      tableClass = Css("guitars"),
-      headerCellFn = Some(HTMLTableBuilder.sortableHeaderCellFn()),
-      footer = guitarFooter
-    )
+        .setHeader("Id"),
+      SortedTableDef.Column("make", _.make).setHeader("Make"),
+      SortedTableDef.Column("model", _.model).setHeader("Model"),
+      SortedTableDef
+        .ColumnGroup(
+          SortedTableDef.Column("year", _.details.year).setHeader("Year"),
+          SortedTableDef.Column("pickups", _.details.pickups).setHeader("Pickups"),
+          SortedTableDef.Column("color", _.details.color).setHeader("Color")
+        )
+        .setHeader("Details")
+    ).toJSArray
   }
 
-  val virtualizedTable = {
-    val tm = TableMaker[RandomData.Person].withBlockLayout
+  val sortedTableState = SortedTableDef.State().setSortByVarargs(SortingRule("model"))
 
-    val cols = tm.columnArray(
-      tm.accessorColumn("first", _.first).setHeader("First").setWidth(100),
-      tm.accessorColumn("last", _.last).setHeader("Last").setWidth(100),
-      tm.accessorColumn("age", _.age).setHeader("Age").setWidth(50)
-    )
+  // TABLE 2
+  val VirtualizedTableDef = TableMaker[RandomData.Person].withBlockLayout
 
-    val options = tm.options(rowIdFn = _.id.toString, columns = cols)
-
+  val VirtualizedTable =
     HTMLTableBuilder.buildComponentVirtualized(
-      tm,
-      options = options,
+      VirtualizedTableDef,
       tableClass = Css("virtualized"),
       rowClassFn = rowClassEvenOdd,
       headerCellFn = Some(HTMLTableBuilder.basicHeaderCellFn(useDiv = true))
     )
-  }
 
-  val sortedVirtualizedTable = {
-    val tm = TableMaker[RandomData.Person].withSort.withBlockLayout
+  val virtualizedTableColumns = List(
+    VirtualizedTableDef.Column("first", _.first).setHeader("First").setWidth(100),
+    VirtualizedTableDef.Column("last", _.last).setHeader("Last").setWidth(100),
+    VirtualizedTableDef.Column("age", _.age).setHeader("Age").setWidth(50)
+  ).toJSArray
 
-    val cols = tm.columnArray(
-      tm.accessorColumn("first", _.first).setHeader("First").setWidth(100),
-      tm.accessorColumn("last", _.last).setHeader("Last").setWidth(100),
-      tm.accessorColumn("age", _.age).setHeader("Age").setWidth(75)
-    )
+  // TABLE 3
+  val SortedVirtualizedTableDef = TableMaker[RandomData.Person].withSort.withBlockLayout
 
-    val options = tm.options(rowIdFn = _.id.toString, columns = cols)
-
+  val SortedVirtualizedTable =
     HTMLTableBuilder.buildComponentVirtualized(
-      tm,
-      options = options,
+      SortedVirtualizedTableDef,
       tableClass = Css("virtualized"),
       headerCellFn = Some(HTMLTableBuilder.sortableHeaderCellFn(useDiv = true))
     )
-  }
 
-  val sortedVariableVirtualizedTable = {
-    def rowClassFn: (Int, RandomData.Person) => Css = (_, p) =>
-      if (p.id % 2 == 0) Css("") else Css("big")
+  val sortedVirtualizedTableColumns = List(
+    SortedVirtualizedTableDef.Column("first", _.first).setHeader("First").setWidth(100),
+    SortedVirtualizedTableDef.Column("last", _.last).setHeader("Last").setWidth(100),
+    SortedVirtualizedTableDef.Column("age", _.age).setHeader("Age").setWidth(75)
+  ).toJSArray
 
-    val tm                                          = TableMaker[RandomData.Person].withSort.withBlockLayout
+  // Table 4
+  val SortedVariableVirtualizedTableDef = TableMaker[RandomData.Person].withSort.withBlockLayout
 
-    val cols = tm.columnArray(
-      tm.accessorColumn("id", _.id).setHeader("Id").setWidth(50),
-      tm.accessorColumn("first", _.first).setHeader("First").setWidth(100),
-      tm.accessorColumn("last", _.last).setHeader("Last").setWidth(100),
-      tm.accessorColumn("age", _.age).setHeader("Age").setWidth(75)
-    )
-
-    val options = tm.options(rowIdFn = _.id.toString, columns = cols)
-
+  val SortedVariableVirtualizedTable =
     HTMLTableBuilder.buildComponentVirtualized(
-      tm,
-      options = options,
+      SortedVariableVirtualizedTableDef,
       tableClass = Css("virtualized"),
       bodyHeight = Some(300), // make this one a different height
       headerCellFn = Some(HTMLTableBuilder.sortableHeaderCellFn(useDiv = true)),
-      rowClassFn = rowClassFn
+      rowClassFn = (_: Int, p: RandomData.Person) => if (p.id % 2 == 0) Css("") else Css("big")
     )
-  }
+
+  val sortedVariableVirtualizedTableColumns = List(
+    SortedVariableVirtualizedTableDef.Column("id", _.id).setHeader("Id").setWidth(50),
+    SortedVariableVirtualizedTableDef.Column("first", _.first).setHeader("First").setWidth(100),
+    SortedVariableVirtualizedTableDef.Column("last", _.last).setHeader("Last").setWidth(100),
+    SortedVariableVirtualizedTableDef.Column("age", _.age).setHeader("Age").setWidth(75)
+  ).toJSArray
+
   @JSExport
   def main(): Unit = {
 
@@ -154,15 +142,23 @@ object DemoMain {
     <.div(
       <.h1("Demo for scalajs-react-table"),
       <.h2("Sortable table"),
-      sortedTable(guitars),
+      SortedTable(
+        SortedTableDef
+          .Options(sortedTableColumns, guitars)
+          .setInitialStateFull(sortedTableState)
+      ),
       "Click header to sort. Shift-Click for multi-sort.",
       <.h2("Virtualized Table"),
-      virtualizedTable(randomData),
+      VirtualizedTable(VirtualizedTableDef.Options(virtualizedTableColumns, randomData)),
       <.h2("Sortable Virtualized Table"),
-      sortedVirtualizedTable(randomData),
+      SortedVirtualizedTable(
+        SortedVirtualizedTableDef.Options(sortedVirtualizedTableColumns, randomData)
+      ),
       <.h2("Sortable Variable Row Height Virtualized Table"),
       <.h3("Rows with odd id's are taller via CSS."),
-      sortedVariableVirtualizedTable(randomData)
+      SortedVariableVirtualizedTable(
+        SortedVariableVirtualizedTableDef.Options(sortedVariableVirtualizedTableColumns, randomData)
+      )
     )
       .renderIntoDOM(container)
 

--- a/facade/src/main/scala/reactST/reactTable/HTMLTableBuilder.scala
+++ b/facade/src/main/scala/reactST/reactTable/HTMLTableBuilder.scala
@@ -25,7 +25,6 @@ object HTMLTableBuilder {
    * Create a table component based on the configured plugins of a `TableMaker`.
    *
    * @param tableMaker The TableMaker providing the useTable hook.
-   * @param options The table options to use for the table.
    * @param headerCellFn A function to use for creating the <th> elements. Simple ones are provided by the TableMaker object.
    * @param tableClass An optional CSS class to apply to the table element
    * @param rowClassFn An option function that takes the index and the rowData and creates a class for the row. Relying on index does not work well for sortable tables since it is the unsorted index.
@@ -51,14 +50,13 @@ object HTMLTableBuilder {
     State <: TableState[D] // format: on
   ](
     tableMaker:   TableMaker[D, TableOptsD, TableInstanceD, ColumnOptsD, ColumnObjectD, State],
-    options:      TableOptsD,
     headerCellFn: Option[ColumnObjectD => TagMod],
     tableClass:   Css = Css(""),
     rowClassFn:   (Int, D) => Css = (_: Int, _: D) => Css(""),
     footer:       TagMod = TagMod.empty
   ) =
-    ScalaFnComponent[js.Array[D]] { data =>
-      val tableInstance = tableMaker.use(options.setData(data.toJSArray))
+    ScalaFnComponent[TableOptsD] { options =>
+      val tableInstance = tableMaker.use(options)
       val bodyProps     = tableInstance.getTableBodyProps()
 
       val header = headerCellFn.fold(TagMod.empty) { f =>
@@ -119,14 +117,13 @@ object HTMLTableBuilder {
     State <: TableState[D] // format: on
   ](
     tableMaker:        TableMaker[D, TableOptsD, TableInstanceD, ColumnOptsD, ColumnObjectD, State],
-    options:           TableOptsD,
     bodyHeight:        Option[Double] = None,
     headerCellFn:      Option[ColumnObjectD => TagMod],
     tableClass:        Css = Css(""),
     rowClassFn:        (Int, D) => Css = (_: Int, _: D) => Css("")
   )(implicit evidence: TableOptsD <:< LayoutMarker) =
-    ScalaFnComponent[js.Array[D]] { data =>
-      val tableInstance = tableMaker.use(options.setData(data.toJSArray))
+    ScalaFnComponent[TableOptsD] { options =>
+      val tableInstance = tableMaker.use(options)
       val bodyProps     = tableInstance.getTableBodyProps()
 
       val rowComp = (_: Int, row: Row[D]) => {

--- a/facade/src/main/scala/reactST/reactTable/package.scala
+++ b/facade/src/main/scala/reactST/reactTable/package.scala
@@ -3,7 +3,9 @@ package reactST
 import reactST.reactTable.mod._
 
 package object reactTable {
-  type ColumnOptions[D]      = ColumnWithLooseAccessor[D] with ColumnFooter[D]
+  type ColumnOptions[D]      = ColumnWithLooseAccessor[D]
+    with ColumnInterfaceBasedOnValue[D, Any]
+    with ColumnFooter[D]
   type ColumnGroupOptions[D] = ColumnGroup[D] with ColumnFooter[D]
   type ColumnObject[D]       = ColumnInstance[D] with UseTableColumnFooter[D]
 }


### PR DESCRIPTION
* Component now accepts the whole Options object. (Column rendering can change according to props/state).
* Constructor methods in TableMaker:
  * Are now capitalized. Calling them resembles building objects.
  * Only require required arguments.
* Tweak types so that `setCell*` methods can be called on columns via implicit conversion.