### PR TITLE
Avoid illegal plugin combinations. More plugins.

### DIFF
--- a/facade/src/main/scala/reactST/reactTable/HTMLTableBuilder.scala
+++ b/facade/src/main/scala/reactST/reactTable/HTMLTableBuilder.scala
@@ -16,7 +16,6 @@ import reactST.std.Partial
 import scalajs.js
 import scalajs.js.|
 import scalajs.js.JSConverters._
-import TableMaker.LayoutMarker
 import reactTableStrings._
 
 object HTMLTableBuilder {
@@ -49,7 +48,7 @@ object HTMLTableBuilder {
     ColumnObjectD <: ColumnObject[D], 
     State <: TableState[D] // format: on
   ](
-    tableMaker:   TableMaker[D, TableOptsD, TableInstanceD, ColumnOptsD, ColumnObjectD, State],
+    tableMaker:   TableMaker[D, TableOptsD, TableInstanceD, ColumnOptsD, ColumnObjectD, State, _],
     headerCellFn: Option[ColumnObjectD => TagMod],
     tableClass:   Css = Css(""),
     rowClassFn:   (Int, D) => Css = (_: Int, _: D) => Css(""),
@@ -116,12 +115,20 @@ object HTMLTableBuilder {
     ColumnObjectD <: ColumnObject[D], 
     State <: TableState[D] // format: on
   ](
-    tableMaker:        TableMaker[D, TableOptsD, TableInstanceD, ColumnOptsD, ColumnObjectD, State],
-    bodyHeight:        Option[Double] = None,
-    headerCellFn:      Option[ColumnObjectD => TagMod],
-    tableClass:        Css = Css(""),
-    rowClassFn:        (Int, D) => Css = (_: Int, _: D) => Css("")
-  )(implicit evidence: TableOptsD <:< LayoutMarker) =
+    tableMaker:   TableMaker[
+      D,
+      TableOptsD,
+      TableInstanceD,
+      ColumnOptsD,
+      ColumnObjectD,
+      State,
+      Layout.NonTable
+    ],
+    bodyHeight:   Option[Double] = None,
+    headerCellFn: Option[ColumnObjectD => TagMod],
+    tableClass:   Css = Css(""),
+    rowClassFn:   (Int, D) => Css = (_: Int, _: D) => Css("")
+  ) =
     ScalaFnComponent[TableOptsD] { options =>
       val tableInstance = tableMaker.use(options)
       val bodyProps     = tableInstance.getTableBodyProps()

--- a/facade/src/main/scala/reactST/reactTable/Hooks.scala
+++ b/facade/src/main/scala/reactST/reactTable/Hooks.scala
@@ -16,7 +16,7 @@ object Hooks {
     ): TableInstance[D] = js.native
   }
 
-  trait Hook extends js.Object
+  sealed trait Hook extends js.Object
   object Hook {
     implicit def asPluginHook[D](hook: Hook): PluginHook[D] = hook.asInstanceOf[PluginHook[D]]
   }
@@ -28,4 +28,12 @@ object Hooks {
   @JSImport("react-table", "useBlockLayout")
   @js.native
   object useBlockLayout extends Hook
+
+  @JSImport("react-table", "useResizeColumns")
+  @js.native
+  object useResizeColumns extends Hook
+
+  @JSImport("react-table", "useGridLayout")
+  @js.native
+  object useGridLayout extends Hook
 }

--- a/facade/src/main/scala/reactST/reactTable/Layout.scala
+++ b/facade/src/main/scala/reactST/reactTable/Layout.scala
@@ -1,0 +1,6 @@
+package reactST.reactTable
+
+object Layout {
+  type Table
+  type NonTable
+}

--- a/facade/src/main/scala/reactST/reactTable/Plugin.scala
+++ b/facade/src/main/scala/reactST/reactTable/Plugin.scala
@@ -1,0 +1,12 @@
+package reactST.reactTable
+
+import Hooks._
+
+sealed abstract class Plugin(val hook: Hook)
+
+object Plugin {
+  final case object SortBy        extends Plugin(useSortBy)
+  final case object ResizeColumns extends Plugin(useResizeColumns)
+  final case object BlockLayout   extends Plugin(useSortBy)
+  final case object GridLayout    extends Plugin(useGridLayout)
+}

--- a/facade/src/main/scala/reactST/reactTable/Plugin.scala
+++ b/facade/src/main/scala/reactST/reactTable/Plugin.scala
@@ -2,11 +2,17 @@ package reactST.reactTable
 
 import Hooks._
 
-sealed abstract class Plugin(val hook: Hook)
+sealed abstract class Plugin(val hook: Hook) extends Ordered[Plugin] {
+  def compare(that: Plugin): Int = Plugin.index(this) - Plugin.index(that)
+}
 
 object Plugin {
   final case object SortBy        extends Plugin(useSortBy)
   final case object ResizeColumns extends Plugin(useResizeColumns)
-  final case object BlockLayout   extends Plugin(useSortBy)
+  final case object BlockLayout   extends Plugin(useBlockLayout)
   final case object GridLayout    extends Plugin(useGridLayout)
+
+  val all: List[Plugin] = List(SortBy, ResizeColumns, BlockLayout, GridLayout)
+
+  val index: Map[Plugin, Int] = all.zipWithIndex.toMap
 }

--- a/facade/src/main/scala/reactST/reactTable/TableMaker.scala
+++ b/facade/src/main/scala/reactST/reactTable/TableMaker.scala
@@ -103,7 +103,7 @@ case class TableMaker[D,
    */
   def use(options: TableOptsD): TableInstanceD =
     Hooks
-      .useTable(options, plugins.map(_.hook: PluginHook[D]).toList: _*)
+      .useTable(options, plugins.toList.sorted.map(_.hook: PluginHook[D]): _*)
       .asInstanceOf[TableInstanceD]
 
   /*

--- a/facade/src/main/scala/reactST/reactTable/mod/useGridLayout.scala
+++ b/facade/src/main/scala/reactST/reactTable/mod/useGridLayout.scala
@@ -1,0 +1,21 @@
+package reactST.reactTable.mod
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.`|`
+import scala.scalajs.js.annotation.{ JSBracketAccess, JSGlobal, JSGlobalScope, JSImport, JSName }
+
+object useGridLayout {
+
+  @scala.inline
+  def apply[D /* <: js.Object */ ](hooks: Hooks[D]): Unit =
+    ^.asInstanceOf[js.Dynamic].apply(hooks.asInstanceOf[js.Any]).asInstanceOf[Unit]
+
+  @JSImport("react-table", "useGridLayout")
+  @js.native
+  val ^ : js.Any = js.native
+
+  @JSImport("react-table", "useGridLayout.pluginName")
+  @js.native
+  val pluginName: /* "useGridLayout" */ String = js.native
+}


### PR DESCRIPTION
In this PR:

* Plugins are represented by an enumeration. A `TableMaker` can thus be queried for present plugins.
* Facades for `useGridLayout` and `useResizeColumns`.
* Make it impossible to call illegal plugin combinations, namely: a layout when one is already set, or `useResizeColumns` when no layout plugin is set.
* Having a layout plugin is reflected in a new type parameter, thus the `LayoutMarker` is no longer necessary.