### PR TITLE
(Briefly) Typed columns. Cell render function.

### DIFF
--- a/demo/src/main/scala/react/table/demo/DemoMain.scala
+++ b/demo/src/main/scala/react/table/demo/DemoMain.scala
@@ -3,7 +3,6 @@ package react.table.demo
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSExportTopLevel
 
-import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import org.scalajs.dom
 import react.common.Css
@@ -48,20 +47,12 @@ object DemoMain {
 
   import ColumnInterfaceBasedOnValue._
 
-  val sortedTableColumns = {
-    val idRenderer = ScalaComponent
-      .builder[Guitar]
-      .render_P(props => <.span(s"g-${props.id}"))
-      .build
-      .cmapCtorProps[(CellProps[Guitar, _]) with js.Object](_.cell.row.original)
-      .toJsComponent
-      .raw
-
+  val sortedTableColumns =
     List(
       SortedTableDef
         .Column("id", _.id)
-        .setCell(idRenderer)
-        .setSortByFn[Int](_.id)
+        .setCell(cell => <.span(s"g-${cell.value}"))
+        .setSortByOrdering
         .setHeader("Id"),
       SortedTableDef.Column("make", _.make).setHeader("Make"),
       SortedTableDef.Column("model", _.model).setHeader("Model"),
@@ -73,7 +64,6 @@ object DemoMain {
         )
         .setHeader("Details")
     ).toJSArray
-  }
 
   val sortedTableState = SortedTableDef.State().setSortByVarargs(SortingRule("model"))
 

--- a/facade/src/main/scala/reactST/reactTable/HTMLTableBuilder.scala
+++ b/facade/src/main/scala/reactST/reactTable/HTMLTableBuilder.scala
@@ -111,7 +111,7 @@ object HTMLTableBuilder {
   def buildComponentVirtualized[D,
     TableOptsD <: UseTableOptions[D], 
     TableInstanceD <: TableInstance[D], 
-    ColumnOptsD <: ColumnOptions[D], 
+    ColumnOptsD <: ColumnOptions[D],
     ColumnObjectD <: ColumnObject[D], 
     State <: TableState[D] // format: on
   ](

--- a/facade/src/main/scala/reactST/reactTable/package.scala
+++ b/facade/src/main/scala/reactST/reactTable/package.scala
@@ -3,9 +3,14 @@ package reactST
 import reactST.reactTable.mod._
 
 package object reactTable {
-  type ColumnOptions[D]      = ColumnWithLooseAccessor[D]
-    with ColumnInterfaceBasedOnValue[D, Any]
-    with ColumnFooter[D]
-  type ColumnGroupOptions[D] = ColumnGroup[D] with ColumnFooter[D]
-  type ColumnObject[D]       = ColumnInstance[D] with UseTableColumnFooter[D]
+  type ColumnOptions[D]                                  =
+    ColumnInterface[D]
+      with reactST.reactTable.anon.IdIdType[D]
+      with reactST.reactTable.anon.`0`[D]
+      with reactST.reactTable.anon.`1`[D]
+      with ColumnFooter[D]
+  type ColumnValueOptions[D, V, Col <: ColumnOptions[D]] =
+    Col with ColumnInterfaceBasedOnValue[D, V]
+  type ColumnGroupOptions[D]                             = ColumnGroup[D] with ColumnFooter[D]
+  type ColumnObject[D]                                   = ColumnInstance[D] with UseTableColumnFooter[D]
 }


### PR DESCRIPTION
* During column definition, preserve column value type.
* Implement inline function renderer for `setCell`.
* `setSortByOrdering` method that obtains values automatically and uses implicit `Ordering`.