### PR TITLE
More sort options.

### DIFF
--- a/demo/src/main/scala/react/table/demo/DemoMain.scala
+++ b/demo/src/main/scala/react/table/demo/DemoMain.scala
@@ -52,7 +52,7 @@ object DemoMain {
       SortedTableDef
         .Column("id", _.id)
         .setCell(cell => <.span(s"g-${cell.value}"))
-        .setSortByOrdering
+        .setSortByAuto
         .setHeader("Id"),
       SortedTableDef.Column("make", _.make).setHeader("Make"),
       SortedTableDef.Column("model", _.model).setHeader("Model"),


### PR DESCRIPTION
* `setSortByRowFn` sorts based on a function on the whole row.
* `setSortByFn` sorts based on a function on the column value.
* `setSortByAuto` sorts based on the column value.

All methods require an implicit `Ordering` on the returned value.

Not sure about the `setSortByAuto` name, but `setSortByOrdering` didn't seem appropriate since all of them actually require an `Ordering`.