### PR TITLE
useTable now returns Reusable table instance.

### DIFF
--- a/facade/src/main/scala/reactST/reactTable/TableHooks.scala
+++ b/facade/src/main/scala/reactST/reactTable/TableHooks.scala
@@ -46,9 +46,11 @@ object TableHooks {
       .useMemoBy(_.cols)(_ => _.toJSArray)
       .useMemoBy(_.input.data)(_ => _.toJSArray)
       .buildReturning { (props, cols, rows) =>
-        useTableJS[D, TableInstanceD](
-          props.modOpts(props.tableDef.Options(cols, rows)),
-          props.tableDef.plugins.toList.sorted.map(_.hook: PluginHook[D]): _*
+        Reusable.byRef(
+          useTableJS[D, TableInstanceD](
+            props.modOpts(props.tableDef.Options(cols, rows)),
+            props.tableDef.plugins.toList.sorted.map(_.hook: PluginHook[D]): _*
+          )
         )
       }
 
@@ -98,7 +100,7 @@ object TableHooks {
         step:                Step,
         reuseListC:          Reusability[List[ColumnInterface[D]]],
         reuseListD:          Reusability[List[D]]
-      ): step.Next[TableInstanceD] =
+      ): step.Next[Reusable[TableInstanceD]] =
         useTableBy(_ => tableDefWithOptions)
 
       final def useTableBy[
@@ -123,7 +125,7 @@ object TableHooks {
         step:                Step,
         reuseListC:          Reusability[List[ColumnInterface[D]]],
         reuseListD:          Reusability[List[D]]
-      ): step.Next[TableInstanceD] =
+      ): step.Next[Reusable[TableInstanceD]] =
         api.customBy(ctx => useTableHook(reuseListC, reuseListD)(tableDefWithOptions(ctx)))
     }
 
@@ -153,7 +155,7 @@ object TableHooks {
         step:                Step,
         reuseListC:          Reusability[List[ColumnInterface[D]]],
         reuseListD:          Reusability[List[D]]
-      ): step.Next[TableInstanceD] =
+      ): step.Next[Reusable[TableInstanceD]] =
         super.useTableBy(step.squash(tableDefWithOptions)(_))
 
     }


### PR DESCRIPTION
The tendency seems to be for hooks to return `Reusable` instances, so that they play nice with `renderWithReuse`.

We consider a table instance to be reusable only if the hook returns the exact same object by reference.