### PR TITLE
Require Reusable hook parameters and return Reusable tableInstance

### DIFF
--- a/demo/src/main/scala/react/table/demo/DemoMain.scala
+++ b/demo/src/main/scala/react/table/demo/DemoMain.scala
@@ -6,7 +6,7 @@ import org.scalajs.dom
 import react.common.Css
 import reactST.reactTable.HTMLTable
 import reactST.reactTable.TableDef
-import reactST.reactTable.TableHooks.Implicits._
+import reactST.reactTable.implicits._
 import reactST.reactTable.mod.{ ^ => _, _ }
 
 import scala.scalajs.js
@@ -25,19 +25,16 @@ object DemoMain {
   def rowClassEvenOdd[D]: (Int, D) => Css = (i, _) => if (i % 2 == 0) Css("even") else Css("odd")
 
   val guitars =
-    List(
-      Guitar(1, "Fender", "Stratocaster", Details(2019, 3, "Sunburst")),
-      Guitar(2, "Gibson", "Les Paul", Details(1958, 2, "Gold top")),
-      Guitar(3, "Fender", "Telecaster", Details(1971, 2, "Ivory")),
-      Guitar(4, "Godin", "LG", Details(2008, 2, "Burgundy"))
+    Reusable.always(
+      List(
+        Guitar(1, "Fender", "Stratocaster", Details(2019, 3, "Sunburst")),
+        Guitar(2, "Gibson", "Les Paul", Details(1958, 2, "Gold top")),
+        Guitar(3, "Fender", "Telecaster", Details(1971, 2, "Ivory")),
+        Guitar(4, "Godin", "LG", Details(2008, 2, "Burgundy"))
+      )
     )
 
-  val randomData = RandomData.randomPeople(1000)
-
-  implicit def colReusability[D]: Reusability[List[ColumnInterface[D]]]    =
-    Reusability.always
-  implicit val guitarListReusability: Reusability[List[Guitar]]            = Reusability.always
-  implicit val personListReusability: Reusability[List[RandomData.Person]] = Reusability.always
+  val randomData = Reusable.always(RandomData.randomPeople(1000))
 
   // TABLE 1
   val SortedTableDef = TableDef[Guitar].withSort
@@ -47,11 +44,11 @@ object DemoMain {
 
   val SortedTable =
     ScalaFnComponent
-      .withHooks[(List[ColumnInterface[Guitar]], List[Guitar])]
+      .withHooks[(Reusable[List[ColumnInterface[Guitar]]], Reusable[List[Guitar]])]
       .useTableBy { case (cols, data) =>
-        SortedTableDef(cols, data, _.setInitialStateFull(sortedTableState))
+        SortedTableDef(cols, data, Reusable.always(_.setInitialStateFull(sortedTableState)))
       }
-      .render((_, tableInstance) =>
+      .renderWithReuse((_, tableInstance) =>
         HTMLTable(SortedTableDef)(
           tableClass = Css("guitars"),
           headerCellFn = Some(HTMLTable.sortableHeaderCellFn()),
@@ -62,21 +59,23 @@ object DemoMain {
   import ColumnInterfaceBasedOnValue._
 
   val sortedTableColumns =
-    List(
-      SortedTableDef
-        .Column("id", _.id)
-        .setCell(cell => <.span(s"g-${cell.value}"))
-        .setSortByAuto
-        .setHeader("Id"),
-      SortedTableDef.Column("make", _.make).setHeader("Make"),
-      SortedTableDef.Column("model", _.model).setHeader("Model"),
-      SortedTableDef
-        .ColumnGroup(
-          SortedTableDef.Column("year", _.details.year).setHeader("Year"),
-          SortedTableDef.Column("pickups", _.details.pickups).setHeader("Pickups"),
-          SortedTableDef.Column("color", _.details.color).setHeader("Color")
-        )
-        .setHeader("Details")
+    Reusable.always(
+      List(
+        SortedTableDef
+          .Column("id", _.id)
+          .setCell(cell => <.span(s"g-${cell.value}"))
+          .setSortByAuto
+          .setHeader("Id"),
+        SortedTableDef.Column("make", _.make).setHeader("Make"),
+        SortedTableDef.Column("model", _.model).setHeader("Model"),
+        SortedTableDef
+          .ColumnGroup(
+            SortedTableDef.Column("year", _.details.year).setHeader("Year"),
+            SortedTableDef.Column("pickups", _.details.pickups).setHeader("Pickups"),
+            SortedTableDef.Column("color", _.details.color).setHeader("Color")
+          )
+          .setHeader("Details")
+      )
     )
 
   // TABLE 2
@@ -84,7 +83,9 @@ object DemoMain {
 
   val VirtualizedTable =
     ScalaFnComponent
-      .withHooks[(List[ColumnInterface[RandomData.Person]], List[RandomData.Person])]
+      .withHooks[
+        (Reusable[List[ColumnInterface[RandomData.Person]]], Reusable[List[RandomData.Person]])
+      ]
       .useTableBy { case (cols, data) => VirtualizedTableDef(cols, data) }
       .render((_, tableInstance) =>
         HTMLTable.virtualized(VirtualizedTableDef)(
@@ -94,10 +95,12 @@ object DemoMain {
         )(tableInstance)
       )
 
-  val virtualizedTableColumns = List(
-    VirtualizedTableDef.Column("first", _.first).setHeader("First").setWidth(100),
-    VirtualizedTableDef.Column("last", _.last).setHeader("Last").setWidth(100),
-    VirtualizedTableDef.Column("age", _.age).setHeader("Age").setWidth(50)
+  val virtualizedTableColumns = Reusable.always(
+    List(
+      VirtualizedTableDef.Column("first", _.first).setHeader("First").setWidth(100),
+      VirtualizedTableDef.Column("last", _.last).setHeader("Last").setWidth(100),
+      VirtualizedTableDef.Column("age", _.age).setHeader("Age").setWidth(50)
+    )
   )
 
   // TABLE 3
@@ -105,7 +108,9 @@ object DemoMain {
 
   val SortedVirtualizedTable =
     ScalaFnComponent
-      .withHooks[(List[ColumnInterface[RandomData.Person]], List[RandomData.Person])]
+      .withHooks[
+        (Reusable[List[ColumnInterface[RandomData.Person]]], Reusable[List[RandomData.Person]])
+      ]
       .useTableBy { case (cols, data) => SortedVirtualizedTableDef(cols, data) }
       .render((_, tableInstance) =>
         HTMLTable.virtualized(SortedVirtualizedTableDef)(
@@ -114,10 +119,12 @@ object DemoMain {
         )(tableInstance)
       )
 
-  val sortedVirtualizedTableColumns = List(
-    SortedVirtualizedTableDef.Column("first", _.first).setHeader("First").setWidth(100),
-    SortedVirtualizedTableDef.Column("last", _.last).setHeader("Last").setWidth(100),
-    SortedVirtualizedTableDef.Column("age", _.age).setHeader("Age").setWidth(75)
+  val sortedVirtualizedTableColumns = Reusable.always(
+    List(
+      SortedVirtualizedTableDef.Column("first", _.first).setHeader("First").setWidth(100),
+      SortedVirtualizedTableDef.Column("last", _.last).setHeader("Last").setWidth(100),
+      SortedVirtualizedTableDef.Column("age", _.age).setHeader("Age").setWidth(75)
+    )
   )
 
   // Table 4
@@ -125,7 +132,9 @@ object DemoMain {
 
   val SortedVariableVirtualizedTable =
     ScalaFnComponent
-      .withHooks[(List[ColumnInterface[RandomData.Person]], List[RandomData.Person])]
+      .withHooks[
+        (Reusable[List[ColumnInterface[RandomData.Person]]], Reusable[List[RandomData.Person]])
+      ]
       .useTableBy { case (cols, data) => SortedVariableVirtualizedTableDef(cols, data) }
       .render((_, tableInstance) =>
         HTMLTable.virtualized(SortedVariableVirtualizedTableDef)(
@@ -136,11 +145,13 @@ object DemoMain {
         )(tableInstance)
       )
 
-  val sortedVariableVirtualizedTableColumns = List(
-    SortedVariableVirtualizedTableDef.Column("id", _.id).setHeader("Id").setWidth(50),
-    SortedVariableVirtualizedTableDef.Column("first", _.first).setHeader("First").setWidth(100),
-    SortedVariableVirtualizedTableDef.Column("last", _.last).setHeader("Last").setWidth(100),
-    SortedVariableVirtualizedTableDef.Column("age", _.age).setHeader("Age").setWidth(75)
+  val sortedVariableVirtualizedTableColumns = Reusable.always(
+    List(
+      SortedVariableVirtualizedTableDef.Column("id", _.id).setHeader("Id").setWidth(50),
+      SortedVariableVirtualizedTableDef.Column("first", _.first).setHeader("First").setWidth(100),
+      SortedVariableVirtualizedTableDef.Column("last", _.last).setHeader("Last").setWidth(100),
+      SortedVariableVirtualizedTableDef.Column("age", _.age).setHeader("Age").setWidth(75)
+    )
   )
 
   @JSExport

--- a/facade/src/main/scala/reactST/reactTable/TableDef.scala
+++ b/facade/src/main/scala/reactST/reactTable/TableDef.scala
@@ -3,6 +3,7 @@
 
 package reactST.reactTable
 
+import japgolly.scalajs.react.Reusable
 import japgolly.scalajs.react.facade
 import japgolly.scalajs.react.facade.React.ComponentClassP
 import japgolly.scalajs.react.vdom._
@@ -37,9 +38,9 @@ case class TableDefWithOptions[
     TableStateD,
     Layout
   ],
-  cols:     List[ColumnInterface[D]],
-  data:     List[D],
-  modOpts:  TableOptsD => TableOptsD
+  cols:     Reusable[List[ColumnInterface[D]]],
+  data:     Reusable[List[D]],
+  modOpts:  Reusable[TableOptsD => TableOptsD]
 )
 
 case class TableDef[
@@ -60,9 +61,9 @@ case class TableDef[
   import syntax._
 
   def apply(
-    cols:    List[ColumnInterface[D]],
-    data:    List[D],
-    modOpts: TableOptsD => TableOptsD = identity[TableOptsD] _
+    cols:    Reusable[List[ColumnInterface[D]]],
+    data:    Reusable[List[D]],
+    modOpts: Reusable[TableOptsD => TableOptsD] = Reusable.always(identity[TableOptsD] _)
   ): TableDefWithOptions[
     D,
     TableOptsD,

--- a/facade/src/main/scala/reactST/reactTable/TableHooks.scala
+++ b/facade/src/main/scala/reactST/reactTable/TableHooks.scala
@@ -46,9 +46,11 @@ object TableHooks {
       .useMemoBy(_.cols)(_ => _.toJSArray)
       .useMemoBy(_.input.data)(_ => _.toJSArray)
       .buildReturning { (props, cols, rows) =>
-        useTableJS[D, TableInstanceD](
-          props.modOpts(props.tableDef.Options(cols, rows)),
-          props.tableDef.plugins.toList.sorted.map(_.hook: PluginHook[D]): _*
+        Reusable.byRef(
+          useTableJS[D, TableInstanceD](
+            props.modOpts(props.tableDef.Options(cols, rows)),
+            props.tableDef.plugins.toList.sorted.map(_.hook: PluginHook[D]): _*
+          )
         )
       }
 
@@ -98,7 +100,7 @@ object TableHooks {
         step:                Step,
         reuseListC:          Reusability[List[ColumnInterface[D]]],
         reuseListD:          Reusability[List[D]]
-      ): step.Next[TableInstanceD] =
+      ): step.Next[Reusable[TableInstanceD]] =
         useTableBy(_ => tableDefWithOptions)
 
       final def useTableBy[
@@ -123,7 +125,7 @@ object TableHooks {
         step:                Step,
         reuseListC:          Reusability[List[ColumnInterface[D]]],
         reuseListD:          Reusability[List[D]]
-      ): step.Next[TableInstanceD] =
+      ): step.Next[Reusable[TableInstanceD]] =
         api.customBy(ctx => useTableHook(reuseListC, reuseListD)(tableDefWithOptions(ctx)))
     }
 
@@ -153,7 +155,7 @@ object TableHooks {
         step:                Step,
         reuseListC:          Reusability[List[ColumnInterface[D]]],
         reuseListD:          Reusability[List[D]]
-      ): step.Next[TableInstanceD] =
+      ): step.Next[Reusable[TableInstanceD]] =
         super.useTableBy(step.squash(tableDefWithOptions)(_))
 
     }

--- a/facade/src/main/scala/reactST/reactTable/TableHooks.scala
+++ b/facade/src/main/scala/reactST/reactTable/TableHooks.scala
@@ -20,6 +20,10 @@ object TableHooks {
   def useTableJS[D, TI <: TableInstance[D]](options: TableOptions[D], plugins: PluginHook[D]*): TI =
     js.native
 
+  // According to documentation, react-table memoizes the table state.
+  private implicit def reuseTableState[T <: TableState[_]]: Reusability[T] =
+    Reusability.byRef
+
   def useTableHook[
     D,
     TableOptsD <: UseTableOptions[D],
@@ -28,10 +32,7 @@ object TableHooks {
     ColumnObjectD <: ColumnObject[D],
     TableStateD <: TableState[D],
     Layout
-  ](implicit
-    reuseListC: Reusability[List[ColumnInterface[D]]],
-    reuseListD: Reusability[List[D]]
-  ) =
+  ] =
     CustomHook[
       TableDefWithOptions[
         D,
@@ -46,12 +47,14 @@ object TableHooks {
       .useMemoBy(_.cols)(_ => _.toJSArray)
       .useMemoBy(_.input.data)(_ => _.toJSArray)
       .buildReturning { (props, cols, rows) =>
-        Reusable.byRef(
+        val tableInstance =
           useTableJS[D, TableInstanceD](
             props.modOpts(props.tableDef.Options(cols, rows)),
             props.tableDef.plugins.toList.sorted.map(_.hook: PluginHook[D]): _*
           )
-        )
+        Reusable
+          .implicitly((cols, rows, props.modOpts, tableInstance.state))
+          .withValue(tableInstance)
       }
 
   sealed trait TableHook extends js.Object
@@ -74,106 +77,4 @@ object TableHooks {
   @JSImport("react-table", "useGridLayout")
   @js.native
   object useGridLayout extends TableHook
-
-  object HooksApiExt {
-    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
-
-      final def useTable[
-        D,
-        TableOptsD <: UseTableOptions[D],
-        TableInstanceD <: TableInstance[D],
-        ColumnOptsD <: ColumnOptions[D],
-        ColumnObjectD <: ColumnObject[D],
-        TableStateD <: TableState[D],
-        Layout
-      ](
-        tableDefWithOptions: TableDefWithOptions[
-          D,
-          TableOptsD,
-          TableInstanceD,
-          ColumnOptsD,
-          ColumnObjectD,
-          TableStateD,
-          Layout
-        ]
-      )(implicit
-        step:                Step,
-        reuseListC:          Reusability[List[ColumnInterface[D]]],
-        reuseListD:          Reusability[List[D]]
-      ): step.Next[Reusable[TableInstanceD]] =
-        useTableBy(_ => tableDefWithOptions)
-
-      final def useTableBy[
-        D,
-        TableOptsD <: UseTableOptions[D],
-        TableInstanceD <: TableInstance[D],
-        ColumnOptsD <: ColumnOptions[D],
-        ColumnObjectD <: ColumnObject[D],
-        TableStateD <: TableState[D],
-        Layout
-      ](
-        tableDefWithOptions: Ctx => TableDefWithOptions[
-          D,
-          TableOptsD,
-          TableInstanceD,
-          ColumnOptsD,
-          ColumnObjectD,
-          TableStateD,
-          Layout
-        ]
-      )(implicit
-        step:                Step,
-        reuseListC:          Reusability[List[ColumnInterface[D]]],
-        reuseListD:          Reusability[List[D]]
-      ): step.Next[Reusable[TableInstanceD]] =
-        api.customBy(ctx => useTableHook(reuseListC, reuseListD)(tableDefWithOptions(ctx)))
-    }
-
-    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
-      api: HooksApi.Secondary[Ctx, CtxFn, Step]
-    ) extends Primary[Ctx, Step](api) {
-
-      def useTableBy[
-        D,
-        TableOptsD <: UseTableOptions[D],
-        TableInstanceD <: TableInstance[D],
-        ColumnOptsD <: ColumnOptions[D],
-        ColumnObjectD <: ColumnObject[D],
-        TableStateD <: TableState[D],
-        Layout
-      ](
-        tableDefWithOptions: CtxFn[TableDefWithOptions[
-          D,
-          TableOptsD,
-          TableInstanceD,
-          ColumnOptsD,
-          ColumnObjectD,
-          TableStateD,
-          Layout
-        ]]
-      )(implicit
-        step:                Step,
-        reuseListC:          Reusability[List[ColumnInterface[D]]],
-        reuseListD:          Reusability[List[D]]
-      ): step.Next[Reusable[TableInstanceD]] =
-        super.useTableBy(step.squash(tableDefWithOptions)(_))
-
-    }
-  }
-
-  trait HooksApiExt {
-    import HooksApiExt._
-
-    implicit def hooksExtUseTable1[Ctx, Step <: HooksApi.AbstractStep](
-      api: HooksApi.Primary[Ctx, Step]
-    ): Primary[Ctx, Step] =
-      new Primary(api)
-
-    implicit def hooksExtUseTable2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
-      api: HooksApi.Secondary[Ctx, CtxFn, Step]
-    ): Secondary[Ctx, CtxFn, Step] =
-      new Secondary(api)
-  }
-
-  object Implicits extends HooksApiExt
 }

--- a/facade/src/main/scala/reactST/reactTable/implicits.scala
+++ b/facade/src/main/scala/reactST/reactTable/implicits.scala
@@ -1,0 +1,100 @@
+package reactST.reactTable
+
+import japgolly.scalajs.react._
+import reactST.reactTable.mod._
+
+object HooksApiExt {
+  sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+    final def useTable[
+      D,
+      TableOptsD <: UseTableOptions[D],
+      TableInstanceD <: TableInstance[D],
+      ColumnOptsD <: ColumnOptions[D],
+      ColumnObjectD <: ColumnObject[D],
+      TableStateD <: TableState[D],
+      Layout
+    ](
+      tableDefWithOptions: TableDefWithOptions[
+        D,
+        TableOptsD,
+        TableInstanceD,
+        ColumnOptsD,
+        ColumnObjectD,
+        TableStateD,
+        Layout
+      ]
+    )(implicit
+      step:                Step
+    ): step.Next[Reusable[TableInstanceD]] =
+      useTableBy(_ => tableDefWithOptions)
+
+    final def useTableBy[
+      D,
+      TableOptsD <: UseTableOptions[D],
+      TableInstanceD <: TableInstance[D],
+      ColumnOptsD <: ColumnOptions[D],
+      ColumnObjectD <: ColumnObject[D],
+      TableStateD <: TableState[D],
+      Layout
+    ](
+      tableDefWithOptions: Ctx => TableDefWithOptions[
+        D,
+        TableOptsD,
+        TableInstanceD,
+        ColumnOptsD,
+        ColumnObjectD,
+        TableStateD,
+        Layout
+      ]
+    )(implicit
+      step:                Step
+    ): step.Next[Reusable[TableInstanceD]] =
+      api.customBy(ctx => TableHooks.useTableHook(tableDefWithOptions(ctx)))
+  }
+
+  final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+    api: HooksApi.Secondary[Ctx, CtxFn, Step]
+  ) extends Primary[Ctx, Step](api) {
+
+    def useTableBy[
+      D,
+      TableOptsD <: UseTableOptions[D],
+      TableInstanceD <: TableInstance[D],
+      ColumnOptsD <: ColumnOptions[D],
+      ColumnObjectD <: ColumnObject[D],
+      TableStateD <: TableState[D],
+      Layout
+    ](
+      tableDefWithOptions: CtxFn[TableDefWithOptions[
+        D,
+        TableOptsD,
+        TableInstanceD,
+        ColumnOptsD,
+        ColumnObjectD,
+        TableStateD,
+        Layout
+      ]]
+    )(implicit
+      step:                Step
+    ): step.Next[Reusable[TableInstanceD]] =
+      super.useTableBy(step.squash(tableDefWithOptions)(_))
+
+  }
+}
+
+trait HooksApiExt {
+  import HooksApiExt._
+
+  implicit def hooksExtUseTable1[Ctx, Step <: HooksApi.AbstractStep](
+    api: HooksApi.Primary[Ctx, Step]
+  ): Primary[Ctx, Step] =
+    new Primary(api)
+
+  implicit def hooksExtUseTable2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+    api: HooksApi.Secondary[Ctx, CtxFn, Step]
+  ): Secondary[Ctx, CtxFn, Step] =
+    new Secondary(api)
+}
+
+object implicits extends HooksApiExt


### PR DESCRIPTION
Instead of using universal reusability for columns, rows and options; I think it makes more sense to specify their reusability locally via `Reusable`. Also, this allows to naturally compute reusability of the `tableInstance` returned by the hook (its internal state is also taken into account besides the 3 mentioned parameters).