### PR TITLE
Require unique import

### DIFF
--- a/demo/src/main/scala/react/table/demo/DemoMain.scala
+++ b/demo/src/main/scala/react/table/demo/DemoMain.scala
@@ -4,9 +4,7 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import org.scalajs.dom
 import react.common.Css
-import reactST.reactTable.HTMLTable
-import reactST.reactTable.TableDef
-import reactST.reactTable.implicits._
+import reactST.reactTable._
 import reactST.reactTable.mod.{ ^ => _, _ }
 
 import scala.scalajs.js

--- a/facade/src/main/scala/reactST/reactTable/HooksApiExt.scala
+++ b/facade/src/main/scala/reactST/reactTable/HooksApiExt.scala
@@ -96,5 +96,3 @@ trait HooksApiExt {
   ): Secondary[Ctx, CtxFn, Step] =
     new Secondary(api)
 }
-
-object implicits extends HooksApiExt

--- a/facade/src/main/scala/reactST/reactTable/package.scala
+++ b/facade/src/main/scala/reactST/reactTable/package.scala
@@ -2,7 +2,7 @@ package reactST
 
 import reactST.reactTable.mod._
 
-package object reactTable {
+package object reactTable extends HooksApiExt {
   type ColumnOptions[D]                                  =
     ColumnInterface[D]
       with reactST.reactTable.anon.IdIdType[D]


### PR DESCRIPTION
Add the HookApi extensions to the base package.

This way we only require `import reactST.reactTable._` to use everything.